### PR TITLE
Set preferOutputNodes to true in GetCookOptions

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Sessions/HEU_SessionHAPI.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Sessions/HEU_SessionHAPI.cs
@@ -822,7 +822,7 @@ namespace HoudiniEngineUnity
 	    cookOptions.splitGroupSH = 0;
 	    cookOptions.splitAttrSH = 0;
 	    cookOptions.splitPointsByVertexAttributes = false;
-		cookOptions.preferOutputNodes = true;
+	    cookOptions.preferOutputNodes = true;
 
 	    cookOptions.cookTemplatedGeos = HEU_PluginSettings.CookTemplatedGeos;
 	    cookOptions.maxVerticesPerPrimitive = HEU_PluginSettings.MaxVerticesPerPrimitive;

--- a/Plugins/HoudiniEngineUnity/Scripts/Sessions/HEU_SessionHAPI.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Sessions/HEU_SessionHAPI.cs
@@ -822,6 +822,7 @@ namespace HoudiniEngineUnity
 	    cookOptions.splitGroupSH = 0;
 	    cookOptions.splitAttrSH = 0;
 	    cookOptions.splitPointsByVertexAttributes = false;
+		cookOptions.preferOutputNodes = true;
 
 	    cookOptions.cookTemplatedGeos = HEU_PluginSettings.CookTemplatedGeos;
 	    cookOptions.maxVerticesPerPrimitive = HEU_PluginSettings.MaxVerticesPerPrimitive;


### PR DESCRIPTION
It seems that after parameters of HDA are changes, sometimes output model is not updated, and we get "cached" geometry. Any subsequent changes to parameters are not creating new geometry. Rstarting session helps with that.

After analysis, it seems that it's not cached on side of the plugin - we are getting "old" data from Houdini session.
Experimentally, I tried to change preferOutputNodes - and it seems to help in my case.